### PR TITLE
CRD is compliant with version 1.22+

### DIFF
--- a/operators-examples/openshift-qiskit-operator/operator/deploy/crds/singhp11.io_qiskitplaygrounds_crd.yaml
+++ b/operators-examples/openshift-qiskit-operator/operator/deploy/crds/singhp11.io_qiskitplaygrounds_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: qiskitplaygrounds.singhp11.io
@@ -12,31 +12,31 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: QiskitPlayground is the Schema for the qiskitplaygrounds API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: QiskitPlaygroundSpec defines the desired state of QiskitPlayground
-          type: object
-        status:
-          description: QiskitPlaygroundStatus defines the observed state of QiskitPlayground
-          type: object
-      type: object
   version: v1
   versions:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: QiskitPlayground is the Schema for the qiskitplaygrounds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: QiskitPlaygroundSpec defines the desired state of QiskitPlayground
+            type: object
+          status:
+            description: QiskitPlaygroundStatus defines the observed state of QiskitPlayground
+            type: object
+        type: object


### PR DESCRIPTION
This PR moves the `QiskitPlayground` CRD from using `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1` due to its deprecation in versions 1.22+. The OpenAPIv3 schema is moved from`spec.validation` to `spec.versions[0].schema`. 